### PR TITLE
fix(signin): redirect to dashboard

### DIFF
--- a/features/auth/actions/signin-action.ts
+++ b/features/auth/actions/signin-action.ts
@@ -34,6 +34,6 @@ export const signInAction = createAction<SignInActionInput>({
       maxAge: maxAgeSeconds
     });
 
-    redirect("/auth");
+    redirect("/auth/dashboard");
   }
 });


### PR DESCRIPTION
Changed the post-sign-in redirect path from '/auth' to '/auth/dashboard' to direct users to the dashboard after successful authentication.